### PR TITLE
Add ad4371 qmxfe

### DIFF
--- a/+adi/+QuadMxFE/Tx.m
+++ b/+adi/+QuadMxFE/Tx.m
@@ -172,6 +172,7 @@ classdef Tx < adi.QuadMxFE.Base & adi.common.Tx
        iioDevADF4371_1;
        iioDevADF4371_2;
        iioDevADF4371_3;
+       iioDevHMC7043;
     end
     
     methods
@@ -420,6 +421,7 @@ classdef Tx < adi.QuadMxFE.Base & adi.common.Tx
             obj.iioDevADF4371_1 = getDev(obj, 'adf4371-1');
             obj.iioDevADF4371_2 = getDev(obj, 'adf4371-2');
             obj.iioDevADF4371_3 = getDev(obj, 'adf4371-3');
+            obj.iioDevHMC7043 = getDev(obj, 'hmc7043');
 
             %%
             obj.CheckAndUpdateHW(obj.ChannelNCOFrequenciesChipA,...

--- a/+adi/+QuadMxFE/Tx.m
+++ b/+adi/+QuadMxFE/Tx.m
@@ -168,6 +168,10 @@ classdef Tx < adi.QuadMxFE.Base & adi.common.Tx
        iioDev1;
        iioDev2;
        iioDev3;
+       iioDevADF4371_0;
+       iioDevADF4371_1;
+       iioDevADF4371_2;
+       iioDevADF4371_3;
     end
     
     methods
@@ -412,6 +416,10 @@ classdef Tx < adi.QuadMxFE.Base & adi.common.Tx
             obj.iioDev1 = getDev(obj, obj.devName1);
             obj.iioDev2 = getDev(obj, obj.devName2);
             obj.iioDev3 = getDev(obj, obj.devName3);
+            obj.iioDevADF4371_0 = getDev(obj, 'adf4371-0');
+            obj.iioDevADF4371_1 = getDev(obj, 'adf4371-1');
+            obj.iioDevADF4371_2 = getDev(obj, 'adf4371-2');
+            obj.iioDevADF4371_3 = getDev(obj, 'adf4371-3');
 
             %%
             obj.CheckAndUpdateHW(obj.ChannelNCOFrequenciesChipA,...


### PR DESCRIPTION
Add more devices to QMxFE classes. Including ADF4371 and HMC7043.