### PR TITLE
MxFE single card support

### DIFF
--- a/+adi/+AD9081/Base.m
+++ b/+adi/+AD9081/Base.m
@@ -1,0 +1,150 @@
+classdef (Abstract) Base < matlabshared.libiio.base & ...
+        matlab.system.mixin.CustomIcon & adi.common.Attribute
+    %AD9081 Base Class
+    
+    properties (Nontunable)
+        %SamplesPerFrame Samples Per Frame
+        %   Number of samples per frame, specified as an even positive
+        %   integer from 2 to 16,777,216. Using values less than 3660 can
+        %   yield poor performance.
+        SamplesPerFrame = 2^15;
+    end
+    
+    properties(Nontunable, Hidden)
+        Timeout = Inf;
+        kernelBuffersCount = 2;
+        dataTypeStr = 'int16';
+        phyDevName = 'axi-ad9081-rx-hpc';
+        max_num_data_channels = 4;
+        max_num_coarse_attr_channels = 4;
+        max_num_fine_attr_channels = 4;
+    end
+    
+    properties (Abstract, Hidden, Constant)
+       Type 
+    end
+    
+    methods
+        %% Constructor
+        function obj = Base(varargin)
+            % Returns the matlabshared.libiio.base object
+            coder.allowpcode('plain');
+            obj = obj@matlabshared.libiio.base(varargin{:});
+        end
+        % Check SamplesPerFrame
+        function set.SamplesPerFrame(obj, value)
+            validateattributes( value, { 'double','single' }, ...
+                { 'real', 'positive','scalar', 'finite', 'nonnan', 'nonempty','integer','>',0,'<',2^20+1}, ...
+                '', 'SamplesPerFrame');
+            obj.SamplesPerFrame = value;
+        end
+    end
+    
+    %% API Functions
+    methods (Hidden, Access = protected)
+                
+        function icon = getIconImpl(obj)
+            icon = sprintf(['AD9081 ',obj.Type]);
+        end
+        
+        function CheckAndUpdateHW(obj, value, name, attr, phy, output)
+            if nargin < 6
+                output = false;
+            end
+            if contains(attr,'channel_')
+                N = obj.num_fine_attr_channels;
+                stride = 1;
+            elseif contains(attr,'main_')
+                N = obj.num_coarse_attr_channels;
+                stride = obj.num_fine_attr_channels/N;
+            else
+                error('Unknown attribute name');
+            end
+            tol = 100;
+            s = size(value);
+            c1 = s(1) == 1;
+            c2 = s(2) <= N;
+            assert(c1 && c2,...
+                sprintf('%s expected to be at most size [1x%d]',name,N));
+            if obj.ConnectedToDevice
+                for k=1:N
+                    id = sprintf('voltage%d_i',(k-1)*stride);
+                    obj.setAttributeLongLong(id,attr,value(k),output, tol, phy);
+                end
+            end
+        end
+        
+        function CheckAndUpdateHWFloat(obj, value, name, attr, phy, output)
+            if nargin < 6
+                output = false;
+            end
+            if contains(attr,'channel_')
+                N = obj.num_fine_attr_channels;
+                stride = 1;
+            elseif contains(attr,'main_')
+                N = obj.num_coarse_attr_channels;
+                stride = obj.num_fine_attr_channels/N;
+            else
+                error('Unknown attribute name');
+            end
+            tol = 100;
+            s = size(value);
+            c1 = s(1) == 1;
+            c2 = s(2) <= N;
+            assert(c1 && c2,...
+                sprintf('%s expected to be at most size [1x%d]',name,N));
+            if obj.ConnectedToDevice
+                for k=1:N
+                    id = sprintf('voltage%d_i',(k-1)*stride);
+                    obj.setAttributeDouble(id,attr,value(k),output, tol, phy);
+                end
+            end
+        end
+        
+        function CheckAndUpdateHWBool(obj, value, name, attr, phy, output)
+            if nargin < 6
+                output = false;
+            end
+            if contains(attr,'channel_') || strcmpi(attr,'en')
+                N = obj.num_fine_attr_channels;
+                stride = 1;
+            elseif contains(attr,'main_')
+                N = obj.num_coarse_attr_channels;
+                stride = obj.num_fine_attr_channels/N;
+            else
+                error('Unknown attribute name');
+            end
+            s = size(value);
+            c1 = s(1) == 1;
+            c2 = s(2) <= N;
+            assert(c1 && c2,...
+                sprintf('%s expected to be at most size [1x%d]',name,N));
+            if obj.ConnectedToDevice
+                for k=1:N
+                    id = sprintf('voltage%d_i',(k-1)*stride);
+                    obj.setAttributeBool(id,attr,value(k),output, phy);
+                end
+            end
+        end
+        
+    end
+    
+    %% External Dependency Methods
+    methods (Hidden, Static)
+        
+        function tf = isSupportedContext(bldCfg)
+            tf = matlabshared.libiio.ExternalDependency.isSupportedContext(bldCfg);
+        end
+        
+        function updateBuildInfo(buildInfo, bldCfg)
+            % Call the matlabshared.libiio.method first
+            matlabshared.libiio.ExternalDependency.updateBuildInfo(buildInfo, bldCfg);
+        end
+        
+        function bName = getDescriptiveName(~)
+            bName = 'AD9081';
+        end
+        
+    end
+end
+

--- a/+adi/+AD9081/Rx.m
+++ b/+adi/+AD9081/Rx.m
@@ -1,0 +1,199 @@
+classdef Rx < adi.AD9081.Base & adi.common.Rx & adi.common.Attribute
+    % adi.AD9081.Rx Receive data from the AD9081 high speed ADC
+    %   The adi.AD9081.Rx System object is a signal source that can receive
+    %   complex data from the AD9081.
+    %
+    %   rx = adi.AD9081.Rx;
+    %   rx = adi.AD9081.Rx('uri','192.168.2.1');
+    %
+    %   <a href="http://www.analog.com/media/en/technical-documentation/data-sheets/AD9081.pdf">AD9081 Datasheet</a>
+    %
+    %   See also adi.DAQ2.Rx
+    
+    properties (Dependent)
+        %SamplingRate Sampling Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second. This value is only readable once
+        %   connected to hardware
+        SamplingRate
+    end
+    
+    properties
+        %ChannelNCOFrequencies Channel NCO Frequencies 
+        %   Frequency of NCO in fine decimators in receive path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz, and N is the number of channels available.
+        ChannelNCOFrequencies = [0,0,0,0];
+        %MainNCOFrequencies Main NCO Frequencies 
+        %   Frequency of NCO in fine decimators in receive path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz, and N is the number of channels available.
+        MainNCOFrequencies = [0,0,0,0];
+        %ChannelNCOPhases Channel NCO Phases 
+        %   Frequency of NCO in fine decimators in receive path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz, and N is the number of channels available.
+        ChannelNCOPhases = [0,0,0,0];
+        %MainNCOPhases Main NCO Phases 
+        %   Frequency of NCO in fine decimators in receive path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz, and N is the number of channels available.
+        MainNCOPhases = [0,0,0,0];
+        %TestMode Test Mode 
+        %   Test mode of receive path. Options are:
+        %   'off' 'midscale_short' 'pos_fullscale' 'neg_fullscale' 
+        %   'checkerboard' 'pn9' 'pn32' 'one_zero_toggle' 'user' 'pn7'
+        %   'pn15' 'pn31' 'ramp'
+        TestMode = 'off';
+    end
+    
+    
+    
+    properties (Hidden, Nontunable, Access = protected)
+        isOutput = false;
+    end
+    
+    properties(Nontunable, Hidden, Constant)
+        Type = 'Rx';
+    end
+    
+    properties (Hidden, Constant)
+        ComplexData = true;
+    end
+    
+    properties(Nontunable, Hidden)
+        channel_names = {};
+        num_data_channels = 4;
+        num_coarse_attr_channels = 4;
+        num_fine_attr_channels = 4;
+    end
+    
+    properties (Nontunable, Hidden)
+        devName = 'axi-ad9081-rx-hpc';
+    end
+    
+    properties(Constant, Hidden)
+        TestModeSet = matlab.system.StringSet({ ...
+            'off','midscale_short','pos_fullscale','neg_fullscale'...
+            'checkerboard','pn9','pn32','one_zero_toggle','user','pn7'...
+            'pn15','pn31','ramp'});
+    end
+    
+    methods
+        %% Constructor
+        function obj = Rx(varargin)
+            % Returns the matlabshared.libiio.base object
+            coder.allowpcode('plain');
+            obj = obj@adi.AD9081.Base(varargin{:});
+            obj.uri = 'ip:analog';
+            obj.channel_names = {};
+            for k = 0:(obj.num_data_channels-1)
+                obj.channel_names = [obj.channel_names(:)', ...
+                    {sprintf('voltage%d_i',k)},{sprintf('voltage%d_q',k)}];
+            end
+            
+            % Fill in place holders
+            obj.ChannelNCOFrequencies = zeros(1,obj.num_fine_attr_channels);
+            obj.MainNCOFrequencies = zeros(1,obj.num_coarse_attr_channels);
+            obj.ChannelNCOPhases = zeros(1,obj.num_fine_attr_channels);
+            obj.MainNCOPhases = zeros(1,obj.num_coarse_attr_channels);
+        end
+        
+        function value = get.SamplingRate(obj)
+            if obj.ConnectedToDevice
+                value= obj.getAttributeLongLong('voltage0_i','sampling_frequency',false);
+            else
+                value = NaN;
+            end
+        end
+        
+        % Check ChannelNCOFrequencies
+        function set.ChannelNCOFrequencies(obj, value)
+            obj.CheckAndUpdateHW(value,'ChannelNCOFrequencies',...
+                'channel_nco_frequency', obj.iioDev); %#ok<*MCSUP>
+            obj.ChannelNCOFrequencies = value;
+        end
+        %%
+        % Check MainNCOFrequencies
+        function set.MainNCOFrequencies(obj, value)
+            obj.CheckAndUpdateHW(value,'MainNCOFrequencies',...
+                'main_nco_frequency', obj.iioDev);
+            obj.MainNCOFrequencies = value;
+        end
+        %%
+        % Check ChannelNCOPhases
+        function set.ChannelNCOPhases(obj, value)
+            obj.CheckAndUpdateHW(value,'ChannelNCOPhases',...
+                'channel_nco_phase', obj.iioDev);
+            obj.ChannelNCOPhases = value;
+        end
+        %%
+        % Check MainNCOPhases
+        function set.MainNCOPhases(obj, value)
+            obj.CheckAndUpdateHW(value,'MainNCOPhases',...
+                'main_nco_phase', obj.iioDev);
+            obj.MainNCOPhases = value;
+        end
+        %%
+        % Check TestMode
+        function set.TestMode(obj, value)
+            obj.setAttributeRAW('voltage0_i','test_mode',value,false,...
+                obj.iioDev);
+            obj.TestMode = value;
+        end
+        
+    end 
+    
+    %% API Functions
+    methods (Hidden, Access = protected)
+                
+        function setupInit(obj)
+            % Write all attributes to device once connected through set
+            % methods
+            % Do writes directly to hardware without using set methods.
+            % This is required sine Simulink support doesn't support
+            % modification to nontunable variables at SetupImpl
+                                    
+            % Update attributes
+            obj.setAttributeRAW('voltage0_i','test_mode',...
+                obj.TestMode,false,obj.iioDev);
+            %%
+            obj.CheckAndUpdateHW(obj.ChannelNCOFrequencies,...
+                'ChannelNCOFrequencies','channel_nco_frequency', ...
+                obj.iioDev);
+            %%
+            obj.CheckAndUpdateHW(obj.MainNCOFrequencies,...
+                'MainNCOFrequencies','main_nco_frequency', ...
+                obj.iioDev);
+            %%
+            obj.CheckAndUpdateHW(obj.ChannelNCOPhases,...
+                'ChannelNCOPhases','channel_nco_phase', ...
+                obj.iioDev);
+            %%
+            obj.CheckAndUpdateHW(obj.MainNCOPhases,...
+                'MainNCOPhases','main_nco_phase', ...
+                obj.iioDev);
+
+        end
+
+    end
+    
+    %% External Dependency Methods
+    methods (Hidden, Static)
+        
+        function tf = isSupportedContext(bldCfg)
+            tf = matlabshared.libiio.ExternalDependency.isSupportedContext(bldCfg);
+        end
+        
+        function updateBuildInfo(buildInfo, bldCfg)
+            % Call the matlabshared.libiio.method first
+            matlabshared.libiio.ExternalDependency.updateBuildInfo(buildInfo, bldCfg);
+        end
+        
+        function bName = getDescriptiveName(~)
+            bName = 'AD9081';
+        end
+        
+    end
+end
+

--- a/+adi/+AD9081/Tx.m
+++ b/+adi/+AD9081/Tx.m
@@ -1,0 +1,187 @@
+classdef Tx < adi.AD9081.Base & adi.common.Tx
+    % adi.AD9081.Tx Transmit data from the AD9081 development board
+    %   The adi.AD9081.Tx System object is a signal sink that can tranmsit
+    %   complex data from the AD9081.
+    %
+    %   tx = adi.AD9081.Tx;
+    %   tx = adi.AD9081.Tx('uri','ip:192.168.2.1');
+    %
+    %   <a href="http://www.analog.com/media/en/technical-documentation/data-sheets/AD9081.pdf">AD9081 Datasheet</a>
+
+    properties
+        %ChannelNCOFrequencies Channel NCO Frequencies 
+        %   Frequency of NCO in fine decimators in transmit path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz.
+        ChannelNCOFrequencies = [0,0,0,0];
+        %MainNCOFrequencies Main NCO Frequencies 
+        %   Frequency of NCO in fine decimators in transmit path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz.
+        MainNCOFrequencies = [0,0,0,0];
+        %ChannelNCOPhases Channel NCO Phases 
+        %   Frequency of NCO in fine decimators in transmit path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz.
+        ChannelNCOPhases = [0,0,0,0];
+        %MainNCOPhases Main NCO Phases 
+        %   Frequency of NCO in fine decimators in transmit path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz.
+        MainNCOPhases = [0,0,0,0];
+        %ChannelNCOGainScales Channel NCO Gain Scales 
+        %   Frequency of NCO in fine decimators in transmit path. Property
+        %   must be a [1,N] vector where each value is the frequency of an
+        %   NCO in hertz.
+        ChannelNCOGainScales = [0,0,0,0];
+        %NCOEnables NCO Enables 
+        %   Vector of logicals which enabled individual NCOs in channel
+        %   interpolators
+        NCOEnables = [false,false,false,false];
+    end
+       
+    properties (Hidden, Nontunable, Access = protected)
+        isOutput = true;
+    end
+    
+    properties(Nontunable, Hidden, Constant)
+        Type = 'Tx';
+    end
+    
+    properties (Hidden, Constant)
+        ComplexData = true;
+    end
+    
+    properties (Nontunable, Hidden)
+        channel_names;
+        num_data_channels = 4;
+        num_coarse_attr_channels = 4;
+        num_fine_attr_channels = 4;
+        num_dds_channels = 32;
+        devName = 'axi-ad9081-tx-hpc';
+        phyDev
+    end
+    
+    methods
+        %% Constructor
+        function obj = Tx(varargin)
+            coder.allowpcode('plain');
+            obj = obj@adi.AD9081.Base(varargin{:});
+            obj.uri = 'ip:analog';
+            obj.channel_names = {};
+            for k = 0:(obj.num_data_channels-1)
+                obj.channel_names = [obj.channel_names(:)', ...
+                    {sprintf('voltage%d_i',k)},{sprintf('voltage%d_q',k)}];
+            end
+            
+            obj.dds_channel_names = {};
+            for k=0:obj.num_dds_channels-1
+                obj.dds_channel_names = [...
+                    obj.dds_channel_names(:)',...
+                    {sprintf('altvoltage%d',k)}];
+            end
+            l = obj.num_dds_channels/2;
+            obj.DDSFrequencies = zeros(2,l);
+            obj.DDSPhases = zeros(2,l);
+            obj.DDSScales = zeros(2,l);
+            
+            obj.ChannelNCOFrequencies = zeros(1,obj.num_fine_attr_channels);
+            obj.MainNCOFrequencies = zeros(1,obj.num_coarse_attr_channels);
+            obj.ChannelNCOPhases = zeros(1,obj.num_fine_attr_channels);
+            obj.MainNCOPhases = zeros(1,obj.num_coarse_attr_channels);
+            obj.ChannelNCOGainScales = zeros(1,obj.num_fine_attr_channels);
+            obj.NCOEnables = zeros(1,obj.num_fine_attr_channels) > 0;
+        end
+        % Check ChannelNCOFrequencies
+        function set.ChannelNCOFrequencies(obj, value)
+            obj.CheckAndUpdateHW(value,'ChannelNCOFrequencies',...
+                'channel_nco_frequency', obj.phyDev, true); %#ok<*MCSUP>
+            obj.ChannelNCOFrequencies = value;
+        end
+        %%
+        % Check MainNCOFrequencies
+        function set.MainNCOFrequencies(obj, value)
+            obj.CheckAndUpdateHW(value,'MainNCOFrequencies',...
+                'main_nco_frequency', obj.phyDev, true);
+            obj.MainNCOFrequencies = value;
+        end
+        %%
+        % Check ChannelNCOPhases
+        function set.ChannelNCOPhases(obj, value)
+            obj.CheckAndUpdateHW(value,'ChannelNCOPhases',...
+                'channel_nco_phase', obj.phyDev, true);
+            obj.ChannelNCOPhases = value;
+        end
+        %%
+        % Check MainNCOPhases
+        function set.MainNCOPhases(obj, value)
+            obj.CheckAndUpdateHW(value,'MainNCOPhases',...
+                'main_nco_phase', obj.phyDev, true);
+            obj.MainNCOPhases = value;
+        end
+        %%
+        % Check ChannelNCOGainScales
+        function set.ChannelNCOGainScales(obj, value)
+            obj.CheckAndUpdateHW(value,'ChannelNCOGainScales',...
+                'channel_nco_gain_scale', obj.phyDev, true);
+            obj.ChannelNCOGainScales = value;
+        end
+        %%
+        % Check NCOEnables
+        function set.NCOEnables(obj, value)
+            obj.CheckAndUpdateHWBool(value,'NCOEnables',...
+                'en', obj.phyDev, true);
+            obj.NCOEnables = value;
+        end
+    end
+    
+    %% API Functions
+    methods (Hidden, Access = protected)
+        
+        function setupInit(obj)
+            % Write all attributes to device once connected through set
+            % methods
+            % Do writes directly to hardware without using set methods.
+            % This is required sine Simulink support doesn't support
+            % modification to nontunable variables at SetupImpl
+
+            % Enable TX DMA offload
+%             obj.setDebugAttributeBool('pl_ddr_fifo_enable', 1, getDev(obj, obj.devName));
+
+            % Set main PHY
+            obj.phyDev = getDev(obj, obj.phyDevName);
+
+            %%
+            obj.CheckAndUpdateHW(obj.ChannelNCOFrequencies,...
+                'ChannelNCOFrequencies','channel_nco_frequency', ...
+                obj.phyDev, true);
+            %%
+            obj.CheckAndUpdateHW(obj.MainNCOFrequencies,...
+                'MainNCOFrequencies','main_nco_frequency', ...
+                obj.phyDev, true);
+            %%
+            obj.CheckAndUpdateHW(obj.ChannelNCOPhases,...
+                'ChannelNCOPhases','channel_nco_phase', ...
+                obj.phyDev, true);
+            %%
+            obj.CheckAndUpdateHW(obj.MainNCOPhases,...
+                'MainNCOPhases','main_nco_phase', ...
+                obj.phyDev, true);
+            %%
+            obj.CheckAndUpdateHWFloat(obj.ChannelNCOGainScales,...
+                'ChannelNCOGainScales','channel_nco_gain_scale', ...
+                obj.phyDev, true);
+            %%
+            obj.CheckAndUpdateHWBool(obj.NCOEnables,...
+                'NCOEnables','en', ...
+                obj.phyDev, true);
+            %% DDS
+            obj.ToggleDDS(strcmp(obj.DataSource,'DDS'));
+            if strcmp(obj.DataSource,'DDS')
+                obj.DDSUpdate();
+            end
+        end
+
+    end
+
+end

--- a/+adi/Contents.m
+++ b/+adi/Contents.m
@@ -5,11 +5,14 @@
 %
 % Parts
 % -----------------------
+%   <a href="matlab:help adi.AD9081            ">AD9081</a>         - Mixed-Signal Front End
 %   <a href="matlab:help adi.AD9144            ">AD9144</a>         - High speed DAC
 %   <a href="matlab:help adi.AD9680            ">AD9680</a>         - High speed ADC
 %   <a href="matlab:help adi.AD9467            ">AD9467</a>         - High speed ADC
 %
 % Boards and Platforms
 % -----------------------
+%   <a href="matlab:help adi.AD9081            ">AD9081</a>         - FMC development board for high speed data acquisition
+%   <a href="matlab:help adi.QuadMxFE          ">QuadMxFE</a>       - 16 channel FMC development board for high speed data acquisition
 %   <a href="matlab:help adi.DAQ2              ">DAQ2</a>           - FMC development board for high speed data acquisition
 

--- a/test/AD9081HWTests.m
+++ b/test/AD9081HWTests.m
@@ -1,0 +1,181 @@
+classdef AD9081HWTests < HardwareTests
+    
+    properties
+        uri = 'ip:analog';
+        author = 'ADI';
+    end
+    
+    methods(TestClassSetup)
+        % Check hardware connected
+        function CheckForHardware(testCase)
+            Device = @()adi.AD9081.Rx;
+            testCase.CheckDevice('ip',Device,testCase.uri(4:end),false);
+        end
+    end
+    
+    methods (Static)
+        function estFrequency(data,fs)
+            nSamp = length(data);
+            FFTRxData  = fftshift(10*log10(abs(fft(data))));
+%             df = fs/nSamp;  freqRangeRx = (-fs/2:df:fs/2-df).'/1000;
+%             plot(freqRangeRx, FFTRxData);
+            df = fs/nSamp;  freqRangeRx = (0:df:fs/2-df).'/1000;
+            plot(freqRangeRx, FFTRxData(end-length(freqRangeRx)+1:end,:));
+        end
+        
+        function freq = estFrequencyMax(data,fs)
+            nSamp = length(data);
+            FFTRxData  = fftshift(10*log10(abs(fft(data))));
+            df = fs/nSamp;  freqRangeRx = (0:df:fs/2-df).';
+            [~,ind] = max(FFTRxData(end-length(freqRangeRx)+1:end,:));
+            freq = freqRangeRx(ind);
+        end
+        
+    end
+    
+    methods (Test)
+        
+        function testAD9081Rx(testCase)    
+            % Test Rx DMA data output
+            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx.EnabledChannels = 1;
+            [out, valid] = rx();
+            rx.release();
+            testCase.verifyTrue(valid);
+            testCase.verifyGreaterThan(sum(abs(double(out))),0);
+        end
+        
+        function testAD9081RxWithTxDDS(testCase)
+            % Test DDS output
+            tx = adi.AD9081.Tx('uri',testCase.uri);
+            tx.DataSource = 'DDS';
+            toneFreq = 45e6;
+            tx.DDSFrequencies = repmat(toneFreq,2,2);
+            tx();
+            pause(1);
+            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx.EnabledChannels = 1;
+            valid = false;
+            for k=1:10
+                [out, valid] = rx();
+            end
+            rx.release();
+            
+%             plot(real(out));
+%             testCase.estFrequency(out,rx.SamplingRate);
+            freqEst = meanfreq(double(real(out)),rx.SamplingRate);
+
+            testCase.verifyTrue(valid);
+            testCase.verifyGreaterThan(sum(abs(double(out))),0);
+            testCase.verifyEqual(freqEst,toneFreq,'RelTol',0.01,...
+                'Frequency of DDS tone unexpected')
+        end
+        
+        function testAD9081RxWithTxDDSTwoChan(testCase)
+            % Test DDS output
+            tx = adi.AD9081.Tx('uri',testCase.uri);
+            tx.DataSource = 'DDS';
+            toneFreq1 = 160e6;
+            toneFreq2 = 300e6;
+            tx.DDSFrequencies = [toneFreq1,toneFreq2;toneFreq1,toneFreq2];
+            tx.DDSScales = [1,1;0,0].*0.029;
+            tx();
+            pause(1);
+            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx.EnabledChannels = [1 2];
+            valid = false;
+            for k=1:10
+                [out, valid] = rx();
+            end
+            rx.release();
+            
+%             plot(real(out));
+%             testCase.estFrequency(out,rx.SamplingRate);
+            freqEst1 = testCase.estFrequencyMax(out(:,1),rx.SamplingRate);
+            freqEst2 = testCase.estFrequencyMax(out(:,2),rx.SamplingRate);
+%             freqEst1 = meanfreq(double(real(out(:,1))),rx.SamplingRate);
+%             freqEst2 = meanfreq(double(real(out(:,2))),rx.SamplingRate);
+
+            testCase.verifyTrue(valid);
+            testCase.verifyGreaterThan(sum(abs(double(out))),0);
+            testCase.verifyEqual(freqEst1,toneFreq1,'RelTol',0.01,...
+                'Frequency of DDS tone unexpected')
+            testCase.verifyEqual(freqEst2,toneFreq2,'RelTol',0.01,...
+                'Frequency of DDS tone unexpected')
+        end
+        
+        function testAD9081RxWithTxData(testCase)
+            % Test Tx DMA data output
+            amplitude = 2^15; frequency = 40e6;
+            swv1 = dsp.SineWave(amplitude, frequency);
+            swv1.ComplexOutput = false;
+            swv1.SamplesPerFrame = 2^20;
+            swv1.SampleRate = 1e9;
+            y = swv1();
+            
+            tx = adi.AD9081.Tx('uri',testCase.uri);
+            tx.DataSource = 'DMA';
+            tx.EnableCyclicBuffers = true;
+            tx(y);
+            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx.EnabledChannels = 1;
+            for k=1:10
+                [out, valid] = rx();
+            end
+            rx.release();
+            
+%             plot(real(out));
+            freqEst = meanfreq(double(real(out)),rx.SamplingRate);
+            
+            testCase.verifyTrue(valid);
+            testCase.verifyGreaterThan(sum(abs(double(out))),0);
+            testCase.verifyEqual(freqEst,frequency,'RelTol',0.01,...
+                'Frequency of ML tone unexpected')
+        end
+        
+        function testAD9081RxWithTxDataTwoChan(testCase)
+            % Test Tx DMA data output
+            amplitude = 2^15; toneFreq1 = 40e6;
+            swv1 = dsp.SineWave(amplitude, toneFreq1);
+            swv1.ComplexOutput = false;
+            swv1.SamplesPerFrame = 2^20;
+            swv1.SampleRate = 1e9;
+            y1 = swv1();
+            
+            amplitude = 2^15; toneFreq2 = 180e6;
+            swv1 = dsp.SineWave(amplitude, toneFreq2);
+            swv1.ComplexOutput = false;
+            swv1.SamplesPerFrame = 2^20;
+            swv1.SampleRate = 1e9;
+            y2 = swv1();
+            
+            tx = adi.AD9081.Tx('uri',testCase.uri);
+            tx.DataSource = 'DMA';
+            tx.EnableCyclicBuffers = true;
+            tx.EnabledChannels = [1,2];
+            tx([y1,y2]);
+            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx.EnabledChannels = [1,2];
+            for k=1:10
+                [out, valid] = rx();
+            end
+            rx.release();
+            
+            plot(real(out));
+%             testCase.estFrequency(out,rx.SamplingRate);
+            freqEst1 = testCase.estFrequencyMax(out(:,1),rx.SamplingRate);
+            freqEst2 = testCase.estFrequencyMax(out(:,2),rx.SamplingRate);
+%             freqEst = meanfreq(double(real(out)),rx.SamplingRate);
+            
+            testCase.verifyTrue(valid);
+            testCase.verifyGreaterThan(sum(abs(double(out))),0);
+            testCase.verifyEqual(freqEst1,toneFreq1,'RelTol',0.01,...
+                'Frequency of DDS tone unexpected')
+            testCase.verifyEqual(freqEst2,toneFreq2,'RelTol',0.01,...
+                'Frequency of DDS tone unexpected')
+        end
+        
+    end
+    
+end
+


### PR DESCRIPTION
This code has been tested against the Linux kernel commit https://github.com/analogdevicesinc/linux/commit/2dba5fae0ece9b71b7afe5e2d019a6dd20c23fcf and HDL https://github.com/analogdevicesinc/hdl/commit/ef5f29e66b033aa1870240d22d12128b03e17e69

Functionality is in parity with QMxFE except for clock chip APIs which are not exposed right now.

Code includes tests and documentation.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>