### PR TITLE
Fix DAQ2 channel definitions

### DIFF
--- a/+adi/+AD9144/Tx.m
+++ b/+adi/+AD9144/Tx.m
@@ -23,11 +23,11 @@ classdef Tx < adi.AD9144.Base & adi.common.Tx & adi.common.DDS
     
     properties(Nontunable, Hidden, Constant)
         Type = 'Tx';
-        channel_names = {'voltage0','voltage1'};
     end
     
     properties (Nontunable, Hidden)
         devName = 'axi-ad9144-hpc';
+        channel_names = {'voltage0','voltage1'};
     end
     
     methods

--- a/+adi/+AD9680/Rx.m
+++ b/+adi/+AD9680/Rx.m
@@ -22,11 +22,11 @@ classdef Rx < adi.AD9680.Base & adi.common.Rx
     
     properties(Nontunable, Hidden, Constant)
         Type = 'Rx';
-        channel_names = {'voltage0','voltage1'};
     end
     
     properties (Nontunable, Hidden)
         devName = 'axi-ad9680-hpc';
+        channel_names = {'voltage0','voltage1'};
     end
     
     methods


### PR DESCRIPTION
When the core +common submodule changed the channel definitions became
dynamic which broke DAQ2 and related classes. This fixes the related
channel definitions.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>