### PR TITLE
Boot bin 2018 3 update

### DIFF
--- a/CI/projects/scripts/fsbl_build_zynqmp.tcl
+++ b/CI/projects/scripts/fsbl_build_zynqmp.tcl
@@ -2,9 +2,9 @@
 
 ### Calling script must have system_top.hdf u-boot.elf
 
-
 set cdir [pwd]
 set sdk_loc $cdir/vivado_prj.sdk
+set vversion $argv[0]
 
 ### Create fsbl
 hsi open_hw_design $sdk_loc/system_top.hdf
@@ -13,6 +13,11 @@ sdk setws $sdk_loc
 sdk createhw -name hw_0 -hwspec $sdk_loc/system_top.hdf
 sdk createapp -name fsbl -hwproject hw_0 -proc $cpu_name -os standalone -lang C -app {Zynq MP FSBL}
 configapp -app fsbl build-config release
+if { $vversion eq "2018.3" } {
+        file copy -force xfsbl_ddr_init.c $sdk_loc/fsbl/src
+        file copy -force xfsbl_hooks.c    $sdk_loc/fsbl/src
+        file copy -force xfsbl_hooks.h    $sdk_loc/fsbl/src
+}
 sdk projects -build -type all
 
 ### Create create_pmufw_project.tcl

--- a/CI/projects/scripts/pmufw_zynqmp_win.tcl
+++ b/CI/projects/scripts/pmufw_zynqmp_win.tcl
@@ -1,0 +1,7 @@
+set cdir [pwd]
+set sdk_loc $cdir/vivado_prj.sdk
+
+### Create create_pmufw_project.tcl
+set hwdsgn [open_hw_design $sdk_loc/system_top.hdf]
+generate_app -verbose -hw $hwdsgn -os standalone -proc psu_pmu_0 -app zynqmp_pmufw -compile -sw pmufw -dir pmufw
+quit

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,27 @@ stage("HDL Tests") {
     }
 }
 
+/////////////////////////////////////////////////////
+
+boardNames = ['daq2']
+dockerConfig.add("-e HDLBRANCH=hdl_2018_r2")
+
+stage("Demo Tests") {
+    dockerParallelBuild(boardNames, dockerHost, dockerConfig) { 
+        branchName ->
+        withEnv(['BOARD='+branchName]) {
+            stage("Source") {
+                unstash "builtSources"
+                sh 'make -C ./CI/scripts test_targeting_demos'
+		junit testResults: 'test/*.xml', allowEmptyResults: true
+                archiveArtifacts artifacts: 'test/logs/*', followSymlinks: false, allowEmptyArchive: true
+            }
+        }
+    }
+}
+
+
+
 
 /////////////////////////////////////////////////////
 

--- a/test/DemoTests.m
+++ b/test/DemoTests.m
@@ -1,0 +1,64 @@
+classdef DemoTests < matlab.uitest.TestCase
+    
+    properties
+        root = '';
+    end
+    
+    methods(TestClassSetup)
+        function addpaths(testCase)
+            here = mfilename('fullpath');
+            here = strsplit(here,'/');
+            here = fullfile('/',here{1:end-2});
+            testCase.root = here;
+            addpath(genpath(fullfile(here,'hdl')));
+        end
+        function setupVivado(~)
+            v=ver('matlab'); Release = v.Release;
+            switch Release
+                case '(R2017a)'
+                    vivado = '2016.2';
+                case '(R2017b)'
+                    vivado = '2017.4';
+                case '(R2018b)'
+                    vivado = '2017.4';
+                case '(R2019a)'
+                    vivado = '2018.2';
+                case '(R2019b)'
+                    vivado = '2018.2';
+                case '(R2020a)'
+                    vivado = '2018.2';
+            end
+            if ispc
+                hdlsetuptoolpath('ToolName', 'Xilinx Vivado', ...
+                    'ToolPath', ['C:\Xilinx\Vivado\',vivado,'\bin\vivado.bat']);
+            elseif isunix
+                hdlsetuptoolpath('ToolName', 'Xilinx Vivado', ...
+                    'ToolPath', ['/opt/Xilinx/Vivado/',vivado,'/bin/vivado']);
+            end
+            
+        end
+    end
+    
+    methods(TestMethodTeardown)
+        function cleanup_hdl_prj(testCase)
+            if exist(fullpath(testCase.root,'hdl_prj'),'dir')
+                rmdir(fullpath(testCase.root,'hdl_prj'), 's');
+            end
+        end
+    end
+    
+    methods(Test)
+        function buildHDLDAQ2ZCU102_BOOTBIN(testCase)
+            cd(fullfile(testCase.root,'test'));
+            hdlworkflow_daq2_zcu102_rx;
+            if ~isempty(out)
+                disp(out.message);
+            end
+            % Check for BOOT.BIN
+            if exist('hdl_prj/vivado_ip_prj/boot/BOOT.BIN', 'file') ~= 2
+                error('BOOT.BIN Failed');
+            end
+        end
+    end
+    
+end

--- a/test/DemoTests.m
+++ b/test/DemoTests.m
@@ -41,8 +41,9 @@ classdef DemoTests < matlab.uitest.TestCase
     
     methods(TestMethodTeardown)
         function cleanup_hdl_prj(testCase)
-            if exist(fullpath(testCase.root,'hdl_prj'),'dir')
-                rmdir(fullpath(testCase.root,'hdl_prj'), 's');
+            dir = fullfile(testCase.root,'test','hdl_prj');
+            if exist(dir, 'dir')
+                rmdir(fullfile(testCase.root,'test','hdl_prj'), 's');
             end
         end
     end
@@ -50,7 +51,26 @@ classdef DemoTests < matlab.uitest.TestCase
     methods(Test)
         function buildHDLDAQ2ZCU102_BOOTBIN(testCase)
             cd(fullfile(testCase.root,'test'));
-            hdlworkflow_daq2_zcu102_rx;
+            out = hdlworkflow_daq2_zcu102_rx('2018.2');
+            if ~isempty(out)
+                disp(out.message);
+            end
+            % Check for BOOT.BIN
+            if exist('hdl_prj/vivado_ip_prj/boot/BOOT.BIN', 'file') ~= 2
+                error('BOOT.BIN Failed');
+            end
+        end
+        function buildHDLDAQ2ZCU102_BOOTBIN_2018_3(testCase)
+            vivado = '2018.3';
+            if ispc
+                hdlsetuptoolpath('ToolName', 'Xilinx Vivado', ...
+                    'ToolPath', ['C:\Xilinx\Vivado\',vivado,'\bin\vivado.bat']);
+            elseif isunix
+                hdlsetuptoolpath('ToolName', 'Xilinx Vivado', ...
+                    'ToolPath', ['/opt/Xilinx/Vivado/',vivado,'/bin/vivado']);
+            end
+            cd(fullfile(testCase.root,'test'));
+            out = hdlworkflow_daq2_zcu102_rx('2018.2');
             if ~isempty(out)
                 disp(out.message);
             end

--- a/test/adi_build.tcl
+++ b/test/adi_build.tcl
@@ -1,0 +1,73 @@
+global fpga_board
+
+if {[info exists fpga_board]} {
+    puts "==========="
+    puts $fpga_board
+    puts "==========="
+} else {
+    # Set to something not ZCU102
+    set fpga_board "ZYNQ"
+}
+
+# Build the project
+update_compile_order -fileset sources_1
+reset_run impl_1
+reset_run synth_1
+launch_runs synth_1
+wait_on_run synth_1
+launch_runs impl_1 -to_step write_bitstream
+wait_on_run impl_1
+puts "MADE IT HERE"
+
+# Define local variables
+set cdir [pwd]
+set sdk_loc vivado_prj.sdk
+
+# Export the hdf
+file delete -force $sdk_loc
+file mkdir $sdk_loc
+file copy -force vivado_prj.runs/impl_1/system_top.sysdef $sdk_loc/system_top.hdf
+
+# Close the Vivado project
+close_project
+puts "MADE IT HERE2"
+
+# Create the BOOT.bin
+#exec xsdk -batch -source $cdir/projects/scripts/fsbl_build.tcl -tclargs $fpga_board -wait
+
+if {$fpga_board eq "ZCU102"} {
+    puts "Building PMUFW"
+    exec hsi -verbose -source $cdir/projects/scripts/pmufw_zynqmp.tcl
+    puts "Done Building PMUFW"
+
+    if {[file exist pmufw/executable.elf] eq 0} {
+        puts "ERROR: pmufw not built"
+        return -code error 10
+    } else {
+        puts "pmufw built correctly!"
+    }
+   
+    set vversion [version -short]
+    exec xsdk -batch -source $cdir/projects/scripts/fsbl_build_zynqmp.tcl $vversion 
+    if {[file exist boot/BOOT.BIN] eq 0} {
+        puts "ERROR: BOOT.BIN not built"
+        return -code error 11
+    } else {
+        puts "BOOT.BIN built correctly!"
+    }
+
+} else {
+    exec xsdk -batch -source $cdir/projects/scripts/fsbl_build_zynq.tcl
+    if {[file exist boot/BOOT.BIN] eq 0} {
+        puts "ERROR: BOOT.BIN not built"
+        return -code error 11
+    } else {
+        puts "BOOT.BIN built correctly!"
+    }
+}
+
+puts "------------------------------------"
+puts "Embedded system build completed."
+puts "You may close this shell."
+puts "------------------------------------"
+exit

--- a/test/adi_build_win.tcl
+++ b/test/adi_build_win.tcl
@@ -31,30 +31,18 @@ file copy -force vivado_prj.runs/impl_1/system_top.sysdef $sdk_loc/system_top.hd
 close_project
 
 # Create the BOOT.bin
-#exec xsdk -batch -source $cdir/projects/scripts/fsbl_build.tcl -tclargs $fpga_board -wait
-
 if {$fpga_board eq "ZCU102"} {
-    exec hsi -source $cdir/projects/scripts/pmufw_zynqmp.tcl
-    file copy -force $cdir/projects/scripts/fixmake.sh $cdir/fixmake.sh
-    exec chmod +x fixmake.sh
+    exec hsi -verbose -source $cdir/projects/scripts/pmufw_zynqmp_win.tcl
 
-    #exec ./fixmake.sh
-    #cd pmufw
-    #exec make
-    #cd ..
-    if [catch "exec -ignorestderr ./fixmake.sh" ret opt] {
-        set makeRet [lindex [dict get $opt -errorcode] end]
-        puts "make returned with $makeRet"
-    }
     if {[file exist pmufw/executable.elf] eq 0} {
         puts "ERROR: pmufw not built"
         return -code error 10
     } else {
         puts "pmufw built correctly!"
     }
-
+   
     set vversion [version -short]
-    exec xsdk -batch -source $cdir/projects/scripts/fsbl_build_zynqmp.tcl $vversion    
+    exec xsdk -batch -source $cdir/projects/scripts/fsbl_build_zynqmp.tcl $vversion 
     if {[file exist boot/BOOT.BIN] eq 0} {
         puts "ERROR: BOOT.BIN not built"
         return -code error 11

--- a/test/hdlworkflow_daq2_zcu102_rx.m
+++ b/test/hdlworkflow_daq2_zcu102_rx.m
@@ -1,0 +1,153 @@
+%--------------------------------------------------------------------------
+% HDL Workflow Script
+% Generated with MATLAB 9.8 (R2020a) at 12:56:00 on 24/09/2020
+% This script was generated using the following parameter values:
+%     Filename  : '/tmp/hsx-add-boot-bin-test/test/hdlworkflow_daq2_zcu102_rx.m'
+%     Overwrite : true
+%     Comments  : true
+%     Headers   : true
+%     DUT       : 'testModel_Rx64Tx64/HDL_DUT'
+% To view changes after modifying the workflow, run the following command:
+% >> hWC.export('DUT','testModel_Rx64Tx64/HDL_DUT');
+%--------------------------------------------------------------------------
+
+%% Load the Model
+load_system('testModel_Rx64Tx64');
+
+%% Restore the Model to default HDL parameters
+%hdlrestoreparams('testModel_Rx64Tx64/HDL_DUT');
+
+%% Model HDL Parameters
+%% Set Model 'testModel_Rx64Tx64' HDL parameters
+hdlset_param('testModel_Rx64Tx64', 'HDLSubsystem', 'testModel_Rx64Tx64/HDL_DUT');
+hdlset_param('testModel_Rx64Tx64', 'ReferenceDesign', 'DAQ2 ZCU102 (RX)');
+hdlset_param('testModel_Rx64Tx64', 'SynthesisTool', 'Xilinx Vivado');
+hdlset_param('testModel_Rx64Tx64', 'SynthesisToolChipFamily', 'Zynq UltraScale+');
+hdlset_param('testModel_Rx64Tx64', 'SynthesisToolDeviceName', 'xczu9eg-ffvb1156-2-e');
+hdlset_param('testModel_Rx64Tx64', 'SynthesisToolPackageName', '');
+hdlset_param('testModel_Rx64Tx64', 'SynthesisToolSpeedValue', '');
+hdlset_param('testModel_Rx64Tx64', 'TargetDirectory', 'hdl_prj/hdlsrc');
+hdlset_param('testModel_Rx64Tx64', 'TargetLanguage', 'Verilog');
+hdlset_param('testModel_Rx64Tx64', 'TargetPlatform', 'AnalogDevices DAQ2 ZCU102');
+hdlset_param('testModel_Rx64Tx64', 'Workflow', 'IP Core Generation');
+
+% Set SubSystem HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT', 'AXI4SlaveIDWidth', '12');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT', 'ProcessorFPGASynchronization', 'Free running');
+
+% Set Inport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in1', 'IOInterface', 'DAQ2 ADC Data 0 IN [0:63]');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in1', 'IOInterfaceMapping', '[0:63]');
+
+% Set Inport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in2', 'IOInterface', 'DAQ2 ADC Data 1 IN [0:63]');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in2', 'IOInterfaceMapping', '[0:63]');
+
+% Set Inport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in3', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in3', 'IOInterfaceMapping', '');
+
+% Set Inport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in4', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in4', 'IOInterfaceMapping', '');
+
+% Set Inport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in5', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in5', 'IOInterfaceMapping', '');
+
+% Set Inport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in6', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in6', 'IOInterfaceMapping', '');
+
+% Set Inport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in7', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in7', 'IOInterfaceMapping', '');
+
+% Set Inport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in8', 'IOInterface', 'DAQ2 Data Valid IN');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/in8', 'IOInterfaceMapping', '[0]');
+
+% Set Outport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out1', 'IOInterface', 'IP Data 0 OUT [0:63]');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out1', 'IOInterfaceMapping', '[0:63]');
+
+% Set Outport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out2', 'IOInterface', 'IP Data 1 OUT [0:63]');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out2', 'IOInterfaceMapping', '[0:63]');
+
+% Set Outport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out3', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out3', 'IOInterfaceMapping', '');
+
+% Set Outport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out4', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out4', 'IOInterfaceMapping', '');
+
+% Set Outport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out5', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out5', 'IOInterfaceMapping', '');
+
+% Set Outport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out6', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out6', 'IOInterfaceMapping', '');
+
+% Set Outport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out7', 'IOInterface', 'No Interface Specified');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out7', 'IOInterfaceMapping', '');
+
+% Set Outport HDL parameters
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out8', 'IOInterface', 'IP Data Valid OUT');
+hdlset_param('testModel_Rx64Tx64/HDL_DUT/out8', 'IOInterfaceMapping', '[0]');
+
+
+%% Workflow Configuration Settings
+% Construct the Workflow Configuration Object with default settings
+hWC = hdlcoder.WorkflowConfig('SynthesisTool','Xilinx Vivado','TargetWorkflow','IP Core Generation');
+
+% Specify the top level project directory
+hWC.ProjectFolder = 'hdl_prj';
+hWC.ReferenceDesignToolVersion = '2018.2';
+hWC.IgnoreToolVersionMismatch = false;
+
+% Set Workflow tasks to run
+hWC.RunTaskGenerateRTLCodeAndIPCore = true;
+hWC.RunTaskCreateProject = true;
+hWC.RunTaskGenerateSoftwareInterfaceModel = false;
+hWC.RunTaskBuildFPGABitstream = true;
+hWC.RunTaskProgramTargetDevice = true;
+
+% Set properties related to 'RunTaskGenerateRTLCodeAndIPCore' Task
+hWC.IPCoreRepository = '';
+hWC.GenerateIPCoreReport = true;
+
+% Set properties related to 'RunTaskCreateProject' Task
+hWC.Objective = hdlcoder.Objective.None;
+hWC.AdditionalProjectCreationTclFiles = '';
+hWC.EnableIPCaching = false;
+
+% Set properties related to 'RunTaskGenerateSoftwareInterfaceModel' Task
+hWC.OperatingSystem = '';
+
+% Set properties related to 'RunTaskBuildFPGABitstream' Task
+hWC.RunExternalBuild = false;
+hWC.TclFileForSynthesisBuild = hdlcoder.BuildOption.Custom;
+hWC.CustomBuildTclFile = 'adi_build.tcl';
+
+% Set properties related to 'RunTaskProgramTargetDevice' Task
+% hWC.ProgrammingMethod = hdlcoder.ProgrammingMethod.Download;
+
+% Validate the Workflow Configuration Object
+hWC.validate;
+
+%% Run the workflow
+%% Run the workflow
+try
+    hdlcoder.runWorkflow('testModel_Rx64Tx64/HDL_DUT', hWC, 'Verbosity', 'on');
+    bdclose('all');
+    out = [];
+catch ME
+    if exist('hdl_prj/vivado_ip_prj/boot/BOOT.BIN','file')
+       ME = [];
+    end
+    out = ME;%.identifier
+end

--- a/test/hdlworkflow_daq2_zcu102_rx.m
+++ b/test/hdlworkflow_daq2_zcu102_rx.m
@@ -1,3 +1,9 @@
+function out = hdlworkflow_daq2_zcu102_rx(vivado)
+
+if nargin < 1
+	vivado = '2018.2';
+end
+
 %--------------------------------------------------------------------------
 % HDL Workflow Script
 % Generated with MATLAB 9.8 (R2020a) at 12:56:00 on 24/09/2020
@@ -106,15 +112,15 @@ hWC = hdlcoder.WorkflowConfig('SynthesisTool','Xilinx Vivado','TargetWorkflow','
 
 % Specify the top level project directory
 hWC.ProjectFolder = 'hdl_prj';
-hWC.ReferenceDesignToolVersion = '2018.2';
-hWC.IgnoreToolVersionMismatch = false;
+hWC.IgnoreToolVersionMismatch = true;
+hWC.ReferenceDesignToolVersion = vivado;
 
 % Set Workflow tasks to run
 hWC.RunTaskGenerateRTLCodeAndIPCore = true;
 hWC.RunTaskCreateProject = true;
 hWC.RunTaskGenerateSoftwareInterfaceModel = false;
 hWC.RunTaskBuildFPGABitstream = true;
-hWC.RunTaskProgramTargetDevice = true;
+hWC.RunTaskProgramTargetDevice = false;
 
 % Set properties related to 'RunTaskGenerateRTLCodeAndIPCore' Task
 hWC.IPCoreRepository = '';
@@ -131,7 +137,11 @@ hWC.OperatingSystem = '';
 % Set properties related to 'RunTaskBuildFPGABitstream' Task
 hWC.RunExternalBuild = false;
 hWC.TclFileForSynthesisBuild = hdlcoder.BuildOption.Custom;
+if ispc
+hWC.CustomBuildTclFile = 'adi_build_win.tcl';
+else
 hWC.CustomBuildTclFile = 'adi_build.tcl';
+end
 
 % Set properties related to 'RunTaskProgramTargetDevice' Task
 % hWC.ProgrammingMethod = hdlcoder.ProgrammingMethod.Download;

--- a/test/runDemoTests.m
+++ b/test/runDemoTests.m
@@ -1,0 +1,44 @@
+function suite = runDemoTests(name)
+
+import matlab.unittest.TestRunner;
+import matlab.unittest.TestSuite;
+import matlab.unittest.plugins.TestReportPlugin;
+import matlab.unittest.plugins.XMLPlugin
+import matlab.unittest.plugins.DiagnosticsValidationPlugin
+
+suite = testsuite({'DemoTests'});
+xmlFile = 'BSPDemoTests.xml';
+
+if nargin > 0
+    xmlFile = [name,'_DemoTests.xml'];
+    suite = suite.selectIf('Name',['*',name,'*']);
+end
+
+
+try
+    runner = matlab.unittest.TestRunner.withTextOutput('OutputDetail',1);
+    runner.addPlugin(DiagnosticsValidationPlugin)
+
+    xmlFile = 'BSPDemoTests.xml';
+    plugin = XMLPlugin.producingJUnitFormat(xmlFile);
+    runner.addPlugin(plugin);
+    
+    results = runner.run(suite);
+    
+    t = table(results);
+    disp(t);
+    disp(repmat('#',1,80));
+    for test = results
+        if test.Failed
+            disp(test.Name);
+        end
+    end
+catch e
+    disp(getReport(e,'extended'));
+    bdclose('all');
+    exit(1);
+end
+
+save(['BSPInstallerTest_',datestr(now,'dd_mm_yyyy-HH:MM:SS'),'.mat'],'t');
+bdclose('all');
+exit(any([results.Failed]));


### PR DESCRIPTION
This PR adds support for ZCU102 Rev 1.1 and Vivado 2018.3. To support this process two separate build tcl scripts for BOOT.BIN generation were created to support windows and Linux since Vivado 2018.3 generates invalid makefiles on Linux.

Two tests were added to check builds between 2018.2 and 2018.3 for valid BOOT.BIN generation.