### PR TITLE
Make ADF4371 PLLs optional for QMxFE

### DIFF
--- a/+adi/+QuadMxFE/Rx.m
+++ b/+adi/+QuadMxFE/Rx.m
@@ -472,16 +472,16 @@ classdef Rx < adi.QuadMxFE.Base & adi.common.Rx
             % Do writes directly to hardware without using set methods.
             % This is required sine Simulink support doesn't support
             % modification to nontunable variables at SetupImpl
-                        
+            
             % Get additional devices
             obj.iioDev0 = getDev(obj, obj.devName0);
             obj.iioDev1 = getDev(obj, obj.devName1);
             obj.iioDev2 = getDev(obj, obj.devName2);
-
-	    % Rev C uses a different DSA
-	    obj.iioHMC425a = iio_context_find_device(obj, obj.iioCtx, 'hmc425a');
+            
+            % Rev C uses a different DSA
+            obj.iioHMC425a = iio_context_find_device(obj, obj.iioCtx, 'hmc425a');
             status = cPtrCheck(obj,obj.iioHMC425a);
-	    if status < 0
+            if status < 0
                 obj.iioHMC425a = getDev(obj, 'hmc540s');
             end
 

--- a/+adi/+QuadMxFE/Tx.m
+++ b/+adi/+QuadMxFE/Tx.m
@@ -425,15 +425,13 @@ classdef Tx < adi.QuadMxFE.Base & adi.common.Tx
             % Enable TX DMA offload
             obj.setDebugAttributeBool('pl_ddr_fifo_enable', 1, 0, getDev(obj, obj.devName));
 
-            % Get SPI connected dev
-            obj.iioDev0 = getDev(obj, obj.devName0);
-            obj.iioDev1 = getDev(obj, obj.devName1);
-            obj.iioDev2 = getDev(obj, obj.devName2);
-            obj.iioDev3 = getDev(obj, obj.devName3);
-            obj.iioDevADF4371_0 = getDev(obj, 'adf4371-0');
-            obj.iioDevADF4371_1 = getDev(obj, 'adf4371-1');
-            obj.iioDevADF4371_2 = getDev(obj, 'adf4371-2');
-            obj.iioDevADF4371_3 = getDev(obj, 'adf4371-3');
+            % Get SPI connected devs
+            for k=0:3
+                obj.(sprintf('iioDevADF4371_%d',k)) = ...
+                    iio_context_find_device(obj, obj.iioCtx, ...
+                    sprintf('adf4371-%d',k));
+            end
+            
             obj.iioDevHMC7043 = getDev(obj, 'hmc7043');
             if obj.CalibrationBoardAttached
                 obj.iioAD5592r = getDev(obj, 'ad5592r');


### PR DESCRIPTION
Make ADF4371 optional since there are modes/configs where they are not now.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>