### PR TITLE
Rename hw test result files

### DIFF
--- a/JenkinsfileHW
+++ b/JenkinsfileHW
@@ -1,6 +1,6 @@
 // Pipeline
 lock(label: 'adgt_test_harness_boards') {
-  @Library('sdgtt-lib@master') _ // Not necessary when we turn on global libraries :)
+  @Library('sdgtt-lib@adgt-test-harness') _ // Not necessary when we turn on global libraries :)
   def hdlBranch = "NA"
   def linuxBranch = "NA"
   def bootPartitionBranch = "release"
@@ -33,16 +33,16 @@ lock(label: 'adgt_test_harness_boards') {
   harness.set_nebula_local_fs_source_root("artifactory.analog.com")
 
   // Set stages (stages are run sequentially on agents)
-  harness.add_stage(harness.stage_library("UpdateBOOTFiles"), 'stopWhenFail',
-                    harness.stage_library("RecoverBoard"))
+  // harness.add_stage(harness.stage_library("UpdateBOOTFiles"), 'stopWhenFail',
+  //                  harness.stage_library("RecoverBoard"))
 
   // Test stage
   harness.set_matlab_commands(["addpath(genpath('test'))",
                         "pyenv('Version','/usr/bin/python3')",
-                        "runHWTests"])
+                        "runHWTests(getenv('board'))"])
   harness.add_stage(harness.stage_library("MATLABTests"),'continueWhenFail')
   
-  // harness.add_stage(harness.stage_library('SendResults'),'continueWhenFail')
+  harness.add_stage(harness.stage_library('SendResults'),'continueWhenFail')
 
   // // Go go
   harness.run_stages()

--- a/test/runHWTests.m
+++ b/test/runHWTests.m
@@ -1,30 +1,33 @@
-import matlab.unittest.TestRunner;
-import matlab.unittest.TestSuite;
-import matlab.unittest.plugins.TestReportPlugin;
-import matlab.unittest.plugins.XMLPlugin
+function runHWTests(board)
 
-try
-    suite = testsuite({'DAQ2Tests'});
-    runner = TestRunner.withNoPlugins;
-    xmlFile = 'HWTestResults.xml';
-    plugin = XMLPlugin.producingJUnitFormat(xmlFile);
-    
-    runner.addPlugin(plugin);
-    results = runner.run(suite);
-    
-    t = table(results);
-    disp(t);
-    disp(repmat('#',1,80));
-    for test = results
-        if test.Failed
-            disp(test.Name);
+    import matlab.unittest.TestRunner;
+    import matlab.unittest.TestSuite;
+    import matlab.unittest.plugins.TestReportPlugin;
+    import matlab.unittest.plugins.XMLPlugin
+
+    try
+        suite = testsuite({'DAQ2Tests'});
+        runner = TestRunner.withNoPlugins;
+        xmlFile = board+"_HWTestResults.xml";
+        plugin = XMLPlugin.producingJUnitFormat(xmlFile);
+        
+        runner.addPlugin(plugin);
+        results = runner.run(suite);
+        
+        t = table(results);
+        disp(t);
+        disp(repmat('#',1,80));
+        for test = results
+            if test.Failed
+                disp(test.Name);
+            end
         end
+    catch e
+        disp(getReport(e,'extended'));
+        bdclose('all');
+        exit(1);
     end
-catch e
-    disp(getReport(e,'extended'));
+    save(['BSPTest_',datestr(now,'dd_mm_yyyy-HH_MM_SS'),'.mat'],'t');
     bdclose('all');
-    exit(1);
+    exit(any([results.Failed]));
 end
-save(['BSPTest_',datestr(now,'dd_mm_yyyy-HH:MM:SS'),'.mat'],'t');
-bdclose('all');
-exit(any([results.Failed]));


### PR DESCRIPTION
- converted runHWTests.m to a function and standardized the filenames of the generated xml files
- Send Results stage is called