### PR TITLE
AD9081HWTests updates

### DIFF
--- a/JenkinsfileHW
+++ b/JenkinsfileHW
@@ -27,7 +27,7 @@ lock(label: 'adgt_test_harness_boards') {
   withCredentials([string(credentialsId: 'netbox_token', variable: 'TOKEN')]) {
     harness.set_env('netbox_token', TOKEN)
   }
-  harness.set_env('netbox_devices_tag','hsc')
+  harness.set_env('netbox_devices_tag','active')
   
   //Update agent with the required deps
   harness.set_required_agent(["sdg-nuc-01","sdg-nuc-02"])
@@ -42,6 +42,9 @@ lock(label: 'adgt_test_harness_boards') {
   harness.set_enable_resource_queuing(true)
   harness.set_lock_agent(true) // Required for MATLAB toolbox tests
   harness.set_elastic_server('192.168.10.1')
+  harness.set_required_hardware(["zynq-zc706-adv7511-fmcdaq2",
+                                 "zynqmp-zcu102-rev10-fmcdaq3",
+                                "zynqmp-zcu102-rev10-ad9081-vm8-l4"])
   harness.set_docker_args(['Vivado', 'MATLAB'])
   harness.set_nebula_local_fs_source_root("artifactory.analog.com")
 

--- a/test/AD9081HWTests.m
+++ b/test/AD9081HWTests.m
@@ -37,7 +37,8 @@ classdef AD9081HWTests < HardwareTests
         
         function testAD9081Rx(testCase)    
             % Test Rx DMA data output
-            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx = adi.AD9081.Rx();
+            rx.uri = testCase.uri;
             rx.EnabledChannels = 1;
             [out, valid] = rx();
             rx.release();
@@ -47,13 +48,15 @@ classdef AD9081HWTests < HardwareTests
         
         function testAD9081RxWithTxDDS(testCase)
             % Test DDS output
-            tx = adi.AD9081.Tx('uri',testCase.uri);
+            tx = adi.AD9081.Tx();
+            tx.uri = testCase.uri;
             tx.DataSource = 'DDS';
             toneFreq = 45e6;
             tx.DDSFrequencies = repmat(toneFreq,2,2);
             tx();
             pause(1);
-            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx = adi.AD9081.Rx();
+            rx.uri = testCase.uri;
             rx.EnabledChannels = 1;
             valid = false;
             for k=1:10
@@ -73,7 +76,8 @@ classdef AD9081HWTests < HardwareTests
         
         function testAD9081RxWithTxDDSTwoChan(testCase)
             % Test DDS output
-            tx = adi.AD9081.Tx('uri',testCase.uri);
+            tx = adi.AD9081.Tx();
+            tx.uri = testCase.uri;
             tx.DataSource = 'DDS';
             toneFreq1 = 160e6;
             toneFreq2 = 300e6;
@@ -81,7 +85,8 @@ classdef AD9081HWTests < HardwareTests
             tx.DDSScales = [1,1;0,0].*0.029;
             tx();
             pause(1);
-            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx = adi.AD9081.Rx();
+            rx.uri = testCase.uri;
             rx.EnabledChannels = [1 2];
             valid = false;
             for k=1:10
@@ -113,11 +118,13 @@ classdef AD9081HWTests < HardwareTests
             swv1.SampleRate = 1e9;
             y = swv1();
             
-            tx = adi.AD9081.Tx('uri',testCase.uri);
+            tx = adi.AD9081.Tx();
+            tx.uri = testCase.uri;
             tx.DataSource = 'DMA';
             tx.EnableCyclicBuffers = true;
             tx(y);
-            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx = adi.AD9081.Rx();
+            rx.uri = testCase.uri;
             rx.EnabledChannels = 1;
             for k=1:10
                 [out, valid] = rx();
@@ -149,12 +156,14 @@ classdef AD9081HWTests < HardwareTests
             swv1.SampleRate = 1e9;
             y2 = swv1();
             
-            tx = adi.AD9081.Tx('uri',testCase.uri);
+            tx = adi.AD9081.Tx();
+            tx.uri = testCase.uri;
             tx.DataSource = 'DMA';
             tx.EnableCyclicBuffers = true;
             tx.EnabledChannels = [1,2];
             tx([y1,y2]);
-            rx = adi.AD9081.Rx('uri',testCase.uri);
+            rx = adi.AD9081.Rx();
+            rx.uri = testCase.uri;
             rx.EnabledChannels = [1,2];
             for k=1:10
                 [out, valid] = rx();


### PR DESCRIPTION
Only the m8_l4 variant is retained. I'm still working on handling other device trees in the tests. uri is also set after constructing the object, otherwise, it would fail to create context. I noticed the same issue with classes in Sensor toolbox.

Signed-off-by: Julia Pineda <Julia.Pineda@analog.com>