### PR TITLE
Update dual AD9213 device names and example

### DIFF
--- a/+adi/+DualAD9213/Rx.m
+++ b/+adi/+DualAD9213/Rx.m
@@ -10,12 +10,17 @@ classdef Rx < adi.AD9213.Rx
     %
     %   See also adi.DAQ2.Rx
            
+    properties (Nontunable, Hidden)
+        phyDevNameChipB = 'ad9213_1';
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
             % Returns the matlabshared.libiio.base object
             coder.allowpcode('plain');
             obj = obj@adi.AD9213.Rx(varargin{:});
+            obj.phyDevName = 'ad9213_0';
             obj.channel_names = {'voltage0','voltage1'};
         end
     end   

--- a/hsx_examples/ad9213/DualAD9213Example.m
+++ b/hsx_examples/ad9213/DualAD9213Example.m
@@ -14,11 +14,11 @@ plot(x);
 %% Perform register writes
 % Split out individual devices for register access
 adc1 = rx.getIIODevice('ad9213_0');
-adc2 = rx.getIIODevice('axi-ad9213-rx-hpc');
+adc2 = rx.getIIODevice('ad9213_1');
 pll1 = rx.getIIODevice('adf4377_0');
 pll2 = rx.getIIODevice('adf4377_1');
-vco = rx.gettIIODevice('ltc6946');
-clock_divs = rx.gettIIODevice('ltc6952');
+vco = rx.getIIODevice('ltc6946');
+clock_divs = rx.getIIODevice('ltc6952');
 
 % Update SPI_TRM_FINE_DLY of both ADCs
 % Reg Maps:
@@ -31,6 +31,12 @@ rx.setRegister(value2,register,adc2);
 % Check
 fprintf('ADC1 Register: %s | Value: %s\n',register,num2str(rx.getRegister(register,adc1)));
 fprintf('ADC2 Register: %s | Value: %s\n',register,num2str(rx.getRegister(register,adc2)));
-
+% Reset JESD204 links
+% Chip A
+rx.setDeviceAttributeRAW('jesd204_fsm_ctrl','0',adc1);
+rx.setDeviceAttributeRAW('jesd204_fsm_ctrl','1',adc1);
+% Chip B
+rx.setDeviceAttributeRAW('jesd204_fsm_ctrl','0',adc2);
+rx.setDeviceAttributeRAW('jesd204_fsm_ctrl','1',adc2);
 % Cleanup
 release(rx);


### PR DESCRIPTION
Update to 2021-R2 and master branch updates for Dual-AD9213 naming and fix example